### PR TITLE
Chore/github action  helf hosted 배포 신규 추가 

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -65,6 +65,5 @@ jobs:
       - name: Setting ENV and Run app
         run: |
           PRODUCTION_ENV=${{ secrets.PRODUCTION_ENV }}
-          echo $PRODUCTION_ENV > .env && source .env
-          pwd
+          echo $PRODUCTION_ENV | base64 --decode > .env && source .env
           node dist/src/main.js

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -62,9 +62,11 @@ jobs:
           npm ci
           npm run build
 
+      # 백그라운드 실행만 설정, 요구사항에 따라 데몬 실행이 가능하게 수정해야 할 수도 있다.
       - name: Setting ENV and Run app
         run: |
           PRODUCTION_ENV=${{ secrets.PRODUCTION_ENV }}
           echo $PRODUCTION_ENV | base64 --decode > .env
           export $(grep -E "^[^#]+=" .env)
-          nohup node dist/src/main.js &
+          nohup node dist/src/main.js & echo $! > node_pid
+          disown $(cat node_pid)

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,16 +1,17 @@
-name: CD self-hosted
+name: Boombim(Back-End) - Build and Deploy
 
-# 이벤트 트리거
 on:
   push:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
+      - v[0-9]+.[0-9]+.[0-9]+-beta.[0-9]+
   # GitHub Actions탭에서 수동실행 가능하도록 설정
   workflow_dispatch:
 
 # 동시성 설정: 같은 그룹의 배포가 여러개 실행되면 가장 마지막에 실행된 배포외에는 취소 시킨다.
+## [참고](https://docs.github.com/ko/actions/using-workflows/workflow-syntax-for-github-actions#example-using-concurrency-to-cancel-any-in-progress-job-or-run)
 concurrency:
-  group: production
+  group: ${{ github.ref }}
   cancel-in-progress: true
 # 환경변수 설정
 env:
@@ -19,10 +20,10 @@ env:
 jobs:
   build: # TODO: ci로 변경예정
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04 #self-hosted 동일한 os 사용
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [v18.14.2]
     steps:
       # github actions 작업 브랜치로 checkout
       - name: Checkout actions Repository
@@ -49,7 +50,7 @@ jobs:
     runs-on: [self-hosted]
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [v18.14.2]
     timeout-minutes: 10 # 10분
     steps:
       # github actions 작업 브랜치로 checkout
@@ -67,13 +68,28 @@ jobs:
           npm ci
           npm run build
 
+      - name: Stop old server (ignore error)
+        run: |
+          killall -9 node || true
+      - name: Remove old server in ~/soruce (ignore error)
+        run: |
+          rm -rf ~/source || true
+      - name: Copy new server to ~/soruce
+        run: |
+          mkdir -p ~/source
+          cp -R ./ ~/source
+
       # 백그라운드 실행만 설정, 데몬 실행 x
       - name: Setting ENV and Run app
         env:
-          RUNNER_TRACKING_ID: ''
+          # 고아프로세스를 죽이지 않는 설정이다.(보안상 위험하기 때문에 꼭 필요한 경우에만 사용한다.)
+          ## [참고](https://www.praetorian.com/blog/self-hosted-github-runners-are-backdoors/)
+          RUNNER_TRACKING_ID: 0 # or ''
         run: |
+          cd ~/source
           PRODUCTION_ENV=${{ secrets.PRODUCTION_ENV }}
           echo $PRODUCTION_ENV | base64 --decode > .env
-          export $(grep -E "^[^#]+=" .env)
-          nohup node dist/src/main.js >> app.log 2>&1 & echo $! > node_pid
+          export $(grep -E "^[^#]+=" .env) && rm .env
+          # 로그 임시로 ~/source 폴더에 저장
+          nohup node dist/src/main.js >> ~/source/app.log 2>&1 & echo $! > node_pid
           disown $(cat node_pid)

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,18 +1,23 @@
-name: CD Docker
+name: CD self-hosted
 
 # 이벤트 트리거
 on:
   push:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
+  # GitHub Actions탭에서 수동실행 가능하도록 설정
+  workflow_dispatch:
 
+# 동시성 설정: 같은 그룹의 배포가 여러개 실행되면 가장 마지막에 실행된 배포외에는 취소 시킨다.
+concurrency:
+  group: production
+  cancel-in-progress: true
 # 환경변수 설정
 env:
   VERSION: ${{ github.sha }}
 
-# 빌드 Job
 jobs:
-  build:
+  build: # TODO: ci로 변경예정
     name: Build
     runs-on: ubuntu-latest
     strategy:
@@ -37,15 +42,15 @@ jobs:
 
   # 배포 Job
   deploy:
-    needs: build # build 후에 실행되도록 정의
+    needs: build
     name: Deploy
-    # self-hosted: 자체 설치 러너에서 작업 수행
-    # label-go: 실행할 러너 라벨명 => 러너 설치시 지정하는 라벨명이다.
+
+    # self-hosted: 물리서버에 설치된 러너에서 작업 수행
     runs-on: [self-hosted]
     strategy:
       matrix:
         node-version: [18.x]
-    timeout-minutes: 5 # 5분
+    timeout-minutes: 10 # 10분
     steps:
       # github actions 작업 브랜치로 checkout
       - name: Checkout actions Repository
@@ -62,8 +67,10 @@ jobs:
           npm ci
           npm run build
 
-      # 백그라운드 실행만 설정, 요구사항에 따라 데몬 실행이 가능하게 수정해야 할 수도 있다.
+      # 백그라운드 실행만 설정, 데몬 실행 x
       - name: Setting ENV and Run app
+        env:
+          RUNNER_TRACKING_ID: ''
         run: |
           PRODUCTION_ENV=${{ secrets.PRODUCTION_ENV }}
           echo $PRODUCTION_ENV | base64 --decode > .env

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -47,20 +47,16 @@ jobs:
     name: Deploy
     # self-hosted: 자체 설치 러너에서 작업 수행
     # label-go: 실행할 러너 라벨명 => 러너 설치시 지정하는 라벨명이다.
-    runs-on: [self-hosted, label-go]
+    runs-on: [self-hosted]
+    timeout-minutes: 5 # 5분
     steps:
       - name: Download Build Artifacts
         uses: actions/download-artifact@v2
         with:
           name: dist
 
-      - name: Copy Files to Runner
-        run: |
-          mkdir -p $HOME/dist
-          cp -r * $HOME/dist
-
       - name: Setting ENV and Run app
         run: |
           PRODUCTION_ENV=${{ secrets.PRODUCTION_ENV }}
           echo $PRODUCTION_ENV > .env && source .env && rm .env
-          node $HOME/dist/src/main
+          node dist/src/main

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -67,4 +67,4 @@ jobs:
           PRODUCTION_ENV=${{ secrets.PRODUCTION_ENV }}
           echo $PRODUCTION_ENV | base64 --decode > .env
           export $(grep -E "^[^#]+=" .env)
-          node dist/src/main.js
+          nohup node dist/src/main.js &

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -35,11 +35,17 @@ jobs:
           npm ci
           npm run build
 
+      - name: Copy build file and node_modules
+        run: |
+          mkdir app
+          cp -r ./dist ./app/dist
+          cp -r ./node_modules ./app/node_modules
+
       - name: Archive Build Artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: app
+          path: app
 
   # 배포 Job
   deploy:
@@ -53,10 +59,10 @@ jobs:
       - name: Download Build Artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
+          name: app
 
       - name: Setting ENV and Run app
         run: |
           PRODUCTION_ENV=${{ secrets.PRODUCTION_ENV }}
           echo $PRODUCTION_ENV > .env && source .env && rm .env
-          node dist/src/main
+          node $HOME/actions-runner/_work/heat-it-be/heat-it-be/app/dist/src/main

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -29,23 +29,11 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
 
-      # build 수행
+      # build 수행 => TODO 이후 테스트 까지 수행해야 의미가 있다.
       - name: Install Dependencies and Build App
         run: |
           npm ci
           npm run build
-
-      - name: Copy build file and node_modules
-        run: |
-          mkdir app
-          cp -r ./dist ./app/dist
-          cp -r ./node_modules ./app/node_modules
-
-      - name: Archive Build Artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: app
-          path: app
 
   # 배포 Job
   deploy:
@@ -56,13 +44,17 @@ jobs:
     runs-on: [self-hosted]
     timeout-minutes: 5 # 5분
     steps:
-      - name: Download Build Artifacts
-        uses: actions/download-artifact@v2
-        with:
-          name: app
+      # github actions 작업 브랜치로 checkout
+      - name: Checkout actions Repository
+        uses: actions/checkout@v2
+
+      - name: Install Dependencies and Build App
+        run: |
+          npm ci
+          npm run build
 
       - name: Setting ENV and Run app
         run: |
           PRODUCTION_ENV=${{ secrets.PRODUCTION_ENV }}
           echo $PRODUCTION_ENV > .env && source .env && rm .env
-          node $HOME/actions-runner/_work/heat-it-be/heat-it-be/app/dist/src/main
+          node dist/src/main.js

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -75,5 +75,5 @@ jobs:
           PRODUCTION_ENV=${{ secrets.PRODUCTION_ENV }}
           echo $PRODUCTION_ENV | base64 --decode > .env
           export $(grep -E "^[^#]+=" .env)
-          nohup node dist/src/main.js & echo $! > node_pid
+          nohup node dist/src/main.js >> app.log 2>&1 & echo $! > node_pid
           disown $(cat node_pid)

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -48,6 +48,12 @@ jobs:
       - name: Checkout actions Repository
         uses: actions/checkout@v2
 
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+
       - name: Install Dependencies and Build App
         run: |
           npm ci

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -65,5 +65,6 @@ jobs:
       - name: Setting ENV and Run app
         run: |
           PRODUCTION_ENV=${{ secrets.PRODUCTION_ENV }}
-          echo $PRODUCTION_ENV | base64 --decode > .env && source .env
+          echo $PRODUCTION_ENV | base64 --decode > .env
+          export $(grep -E "^[^#]+=" .env)
           node dist/src/main.js

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -42,6 +42,9 @@ jobs:
     # self-hosted: 자체 설치 러너에서 작업 수행
     # label-go: 실행할 러너 라벨명 => 러너 설치시 지정하는 라벨명이다.
     runs-on: [self-hosted]
+    strategy:
+      matrix:
+        node-version: [18.x]
     timeout-minutes: 5 # 5분
     steps:
       # github actions 작업 브랜치로 checkout

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,61 @@
+name: CD Docker
+
+# 이벤트 트리거
+on:
+  push:
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+
+
+# 환경변수 설정
+env:
+  VERSION: ${{ github.sha }}
+
+# 빌드 Job
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18.x]
+    steps:
+      # github actions 작업 브랜치로 checkout
+      - name: Checkout actions Repository
+        uses: actions/checkout@v2
+      # node 버전 설정
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+
+      # build 수행
+      - name: Install Dependencies and Build App
+        run: |
+          npm ci
+          npm run build
+
+      - name: Archive Build Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: dist
+          path: dist
+
+  # 배포 Job
+  deploy:
+    needs: build # build 후에 실행되도록 정의
+    name: Deploy
+    # self-hosted: 자체 설치 러너에서 작업 수행
+    # label-go: 실행할 러너 라벨명 => 러너 설치시 지정하는 라벨명이다.
+    runs-on: [self-hosted, label-go]
+    steps:
+      - name: Download Build Artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: dist
+
+      - name: Setting ENV and Run app
+        run: |
+          PRODUCTION_ENV=${{ secrets.PRODUCTION_ENV }}
+          echo $PRODUCTION_ENV > .env && source .env && rm .env
+          node dist/src/main

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -54,8 +54,13 @@ jobs:
         with:
           name: dist
 
+      - name: Copy Files to Runner
+        run: |
+          mkdir -p $HOME/dist
+          cp -r * $HOME/dist
+
       - name: Setting ENV and Run app
         run: |
           PRODUCTION_ENV=${{ secrets.PRODUCTION_ENV }}
           echo $PRODUCTION_ENV > .env && source .env && rm .env
-          node dist/src/main
+          node $HOME/dist/src/main

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -65,5 +65,6 @@ jobs:
       - name: Setting ENV and Run app
         run: |
           PRODUCTION_ENV=${{ secrets.PRODUCTION_ENV }}
-          echo $PRODUCTION_ENV > .env && source .env && rm .env
+          echo $PRODUCTION_ENV > .env && source .env
+          pwd
           node dist/src/main.js

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -18,55 +18,77 @@ env:
   VERSION: ${{ github.sha }}
 
 jobs:
-  build: # TODO: ci로 변경예정
+  build:
     name: Build
     runs-on: ubuntu-22.04 #self-hosted 동일한 os 사용
     strategy:
       matrix:
         node-version: [v18.14.2]
     steps:
-      # github actions 작업 브랜치로 checkout
+      # 1. 워크플로를 수행하기 위해 해당 브랜치로 checkout
       - name: Checkout actions Repository
         uses: actions/checkout@v2
-      # node 버전 설정
+      # 2. node 버전 설정
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'npm'
 
-      # build 수행 => TODO 이후 테스트 까지 수행해야 의미가 있다.
-      - name: Install Dependencies and Build App
-        run: |
-          npm ci
-          npm run build
+      # 3. node_modules 캐시 설정
+      # docs: https://github.com/actions/cache
+      # outputs.cache-hit: 캐시가 존재하면 true, 존재하지 않으면 false
+      - name: Cache node_modules
+        id: cache
+        uses: actions/cache@v3
+        with:
+          # cache의 대상을 정한다.
+          path: '**/node_modules'
+          # 무효화의 기준이 되는 cache의 key를 정한다.
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          # key가 깨졌을때 복구하는 방법 명시, "${{ runner.os }}-node-" 와 일치하는 캐시를 가져와 사용한다.
+          restore-keys: ${{ runner.os }}-node-
+      # 일치하는 캐시가 없다면 의존성 설치
+
+      - name: Install Dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: npm ci
+
+      - name: Run Build App
+        run: npm run build
 
   # 배포 Job
   deploy:
     needs: build
     name: Deploy
-
-    # self-hosted: 물리서버에 설치된 러너에서 작업 수행
+    # self-hosted: 물리서버에 설치된 자체 러너에서 작업 수행
     runs-on: [self-hosted]
+    timeout-minutes: 10 # 10분
     strategy:
       matrix:
         node-version: [v18.14.2]
-    timeout-minutes: 10 # 10분
+
     steps:
-      # github actions 작업 브랜치로 checkout
       - name: Checkout actions Repository
         uses: actions/checkout@v2
-
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'npm'
 
-      - name: Install Dependencies and Build App
-        run: |
-          npm ci
-          npm run build
+      - name: Cache node_modules
+        id: cache
+        uses: actions/cache@v3
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: ${{ runner.os }}-node-
+
+      - name: Install Dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: npm ci
+
+      - name: Run Build App
+        run: npm run build
 
       - name: Stop old server (ignore error)
         run: |
@@ -79,7 +101,7 @@ jobs:
           mkdir -p ~/source
           cp -R ./ ~/source
 
-      # 백그라운드 실행만 설정, 데몬 실행 x
+      # 백그라운드 실행 설정(데몬 실행 x)
       - name: Setting ENV and Run app
         env:
           # 고아프로세스를 죽이지 않는 설정이다.(보안상 위험하기 때문에 꼭 필요한 경우에만 사용한다.)


### PR DESCRIPTION
# PR Summery

## [FEATURE]
배포용 github action workflows 신규 추가
- jobs
  1. 빌드
  2. 배포[self-hosted]


## [WORK-LOG]
### [1. self-hosted 설정 관련](https://docs.github.com/ko/actions/using-jobs/choosing-the-runner-for-a-job#overview)

서버리스가 아닌 서버의 배포는 물리적인 인스턴스에 실행 중인 앱을 종료하고 빌드된 신규 소스로 앱으로 실행하는 것을 말한다 
때문에 github action에서는 아래와 같은 두가지 경우에 대한 실행 환경 제공한다.
1. github에서 제공하는 컨테이너 환경에서 job 실행
2. 직접적인 물리서버에서 job 실행

배포 프로세스는 다양한 솔루션이 존재하지만 MVP 특성상 환경을 집중하는 것이 가장 현명하다고 판단되어 
github action에서 제공하는 방법을 사용하기로 하였다.

### [2. self-hosted에서 node로 앱 실행]
ec2 인스턴스 실행시 스크립트를 통해 nvm과 node가 항상 실행되도록 셋팅하였다.
문제는 self-hosted에서 node 명령도 안되고 심지어 nvm 명령도 정상 실행되지 않았다.
이유를 찾아보니 self-hosted이라고 해도 action을 수행하는 환경은 따로 격리되도록 했다고 한다. 
때문에 self-hosted에 해둔 설정은 의미가 없으며, github action에서 제공하는 환경을 내려받아서 사용해야 한다.
ex)
```
- name: Use Node.js ${{ matrix.node-version }}
        uses: actions/setup-node@v3
        with:
          node-version: ${{ matrix.node-version }}
```

### [3. 고아 프로세스 죽이지 않고 실행 시키기](https://www.praetorian.com/blog/self-hosted-github-runners-are-backdoors/)
self-hosted를 사용하여 앱을 실행시킨다면, 워크플로 종료시 해당 프로세스는 고아 프로세스가 된다.
그리고 GitHub 워크플로는 종료 시 모든 고아 프로세스를 정리한다. (보안상 안전하기 때문이다.) 
그래서 일종의 우회하는 기능이 존재한다. RUNNER_TRACKING_ID 환경변수를 0으로 설정하면 해당 환경변수를 가진 프로세스는 고아 프로세스가 되어도 정리되지 않고 실행이 가능하다.

### [4. 캐시 최적화 과정 수행](https://docs.github.com/ko/actions/using-jobs/choosing-the-runner-for-a-job#overview)
<img width="1380" alt="image" src="https://github.com/2023vworks/heat-it-be/assets/57210007/312c96cc-785a-402c-bbdd-9dae16c9ee80">

속도 비교
1. 캐시 자체를 사용 안한 버전 - 3분 11초
2. deploy 에서 캐싱된 의존성이 사용된 버전 - 2분 29초
3. build , deploy 모두 캐싱된 의존성 사용된 버전 - 1분 55초

### [5.워크플로 실행 동시성](https://docs.github.com/ko/actions/using-workflows/workflow-syntax-for-github-actions#example-using-concurrency-to-cancel-any-in-progress-job-or-run)
물리서버에 직접적인 배포를 해야하는 특성상 배포 프로세스의 동시성에 대해서도 생각을 해야했다. 
github action 공식문서를 보게되면 `concurrency` 설정을 제공하는데 이것을 사용하여 해결하였다.

ex)
```
concurrency:
  group: ${{ github.ref }}
  cancel-in-progress: true
```
- `group` 해당 값을 가진 워크플로우가 동시에 여러게 실행된다면
- `cancel-in-progress`: true 가장 먼저 실행된 워크플로우를 제외하고 모두 취소한다
