### PR TITLE
Feature/geo 데이터를 고민한 도메인 설계 완료

### DIFF
--- a/src/entity/entity.interface.ts
+++ b/src/entity/entity.interface.ts
@@ -1,0 +1,396 @@
+/**
+ * Mbti 타입
+ */
+enum MbtiType {
+  ISTJ = 'ISTJ',
+  ISFJ = 'ISFJ',
+  INFJ = 'INFJ',
+  INTJ = 'INTJ',
+  ISTP = 'ISTP',
+  ISFP = 'ISFP',
+  INFP = 'INFP',
+  INTP = 'INTP',
+  ESTP = 'ESTP',
+  ESFP = 'ESFP',
+  ENFP = 'ENFP',
+  ENTP = 'ENTP',
+  ESTJ = 'ESTJ',
+  ESFJ = 'ESFJ',
+  ENFJ = 'ENFJ',
+  ENTJ = 'ENTJ',
+}
+/**
+ * 추천 타입
+ */
+enum RecommendType {
+  RECOMMEND = 'Recommend',
+  UNRECOMMEND = 'Unrecommend',
+}
+/**
+ * 좌표계 타입
+ */
+enum CoordType {
+  /** 위경도 좌표계 */
+  WGS84 = 'WGS84',
+  WCONGNAMUL = 'WCONGNAMUL',
+  CONGNAMUL = 'CONGNAMUL',
+  WGS84GEO = 'WGS84GEO',
+  WCONGNAMULGEO = 'WCONGNAMULGEO',
+  CONGNAMULGEO = 'CONGNAMULGEO',
+}
+
+export interface User {
+  id: number; // 고유한 값
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt?: Date;
+
+  /**
+   * MBTI 유형
+   */
+  mbtiType: MbtiType;
+
+  /**
+   * 닉네임
+   * - 000 + id,
+   * - default 0000
+   */
+  nickname: string;
+
+  /**
+   * JWT 토큰
+   * - defalt ''
+   */
+  token: string;
+
+  /**
+   * 마지막 접속일
+   * - mvp에서는 생성시 추가
+   * - default now
+   */
+  accessedAt: Date;
+
+  /**
+   * 피드 작성 횟수
+   * - min 0
+   * - max 5
+   * - default 5
+   */
+  feedWritingCount: number;
+
+  /**
+   * 피드 마지막 작성 시간 날짜
+   */
+  lastFeedWrittenAt?: Date | null;
+
+  /* ========== 연관관계 ==========*/
+  feeds: Feed[] | [];
+  comments: Comment[] | [];
+}
+
+export interface Feed {
+  id: number;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt?: Date;
+
+  /**
+   * 피드 활성도
+   * - 1 ~ 5
+   * - default 1
+   */
+  activity: number;
+
+  /**
+   * 피드 내용
+   * - 140자
+   * - 3byte * 140
+   */
+  content: string; // 140자 > 3byte * 140 하면될까?
+
+  /**
+   * 썸네일 이미지 리스트
+   * - min 0
+   * - max 5
+   * - default []
+   */
+  thumbnailImages: string[];
+
+  /**
+   * 이미지 리스트
+   * - min 0
+   * - max 5
+   * - default []
+   */
+  images: string[];
+  /**
+   * 해시태그 리스트
+   * - default []
+   */
+  hashTags: string[];
+  /**
+   * 피드 활성화 여부
+   * - default true
+   */
+  isActive: boolean;
+
+  // 피드 남은 시간 = 생성된 시간 + (추천수 * 30) - (비추천 * 15)
+  /**
+   * 추천수
+   * - default 0
+   */
+  recommendCount: number; // 추천수, default 0
+
+  /**
+   * 비추천수
+   * - default 0
+   */
+  unrecommendCount: number;
+
+  /**
+   * 신고수
+   * - default 0
+   */
+  reportCount: number; // 신고수, default 0
+
+  /**
+   * 노출수
+   * - default 0
+   */
+  view: number;
+
+  /* ========== 연관관계 ==========*/
+  user: User;
+  geoMark: GeoMark;
+  comments: Comment[] | [];
+}
+
+export interface RecommendHistory {
+  id: number;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt?: Date;
+
+  /**
+   * 추천 타입
+   * - 'Recommend' | 'Unrecommend'
+   */
+  type: RecommendType;
+
+  /* ========== 연관관계 ==========*/
+  feed: Feed; // 부모
+  user: User;
+}
+
+export interface ReportHistory {
+  id: number;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt?: Date;
+  /**
+   * 신고 사유
+   */
+  reason: string;
+
+  /* ========== 연관관계 ==========*/
+  feed: Feed; // 부모
+  user: User;
+}
+
+export interface GeoMark {
+  id: string;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt?: Date;
+
+  /**
+   * 경도
+   * - Double
+   * - x = longtitue = 경도
+   */
+  x: number;
+  /**
+   * 위도
+   * - Double
+   * - y = lattitue = 위도
+   */
+  y: number;
+  /**
+   * 좌표계 타입
+   * - default 'WGS84'
+   */
+  type: CoordType;
+
+  /**
+   * 행정구역 정보
+   */
+  regionInfo: RegionInfo;
+
+  /**
+   * 주소 정보
+   */
+  address: Address;
+
+  /**
+   * 도로명 주소 정보
+   */
+  roadAddress?: RoadAddress | null;
+
+  /* ========== 연관관계 ==========*/
+  // 관계
+  feed: Feed;
+}
+
+/**
+ * 좌표로 행정구역정보 받기
+ * @docs https://developers.kakao.com/docs/latest/ko/local/dev-guide#coord-to-district-response-body-document
+ */
+export interface RegionInfo {
+  /**
+   * H(행정동) 또는 B(법정동)
+   */
+  region_type: string;
+  /**
+   * 전체 지역 명칭
+   */
+  address_name: string;
+  /**
+   * 지역 1Depth, 시도 단위 바다 영역은 존재하지 않음
+   */
+  region_1depth_name: string;
+  /**
+   * 지역 2Depth, 구 단위 바다 영역은 존재하지 않음
+   */
+  region_2depth_name: string;
+  /**
+   * 지역 3Depth, 동 단위 바다 영역은 존재하지 않음
+   */
+  region_3depth_name: string;
+  /**
+   * 지역 4Depth, 리 영역인 경우만 존재 region_type이 법정동이며;
+   */
+  region_4depth_name: string;
+  /**
+   * region 코드
+   */
+  code: string;
+  /**
+   * X 좌표값, 경위도인 경우 경도(longitude)
+   * - Double
+   */
+  x: number;
+  /**
+   * Y 좌표값, 경위도인 경우 위도(latitude)
+   * - Double
+   */
+  y: number;
+}
+
+/**
+ * 지번 주소 상세 정보
+ * @docs https://developers.kakao.com/docs/latest/ko/local/dev-guide#coord-to-address-response-body-address
+ */
+export interface Address {
+  /**
+   * 전체 지번 주소
+   */
+  addressName: string;
+
+  /**
+   *  지역 1 Depth, 시도 단위
+   */
+  region1DepthName: string;
+
+  /**
+   *  지역 2 Depth, 구 단위
+   */
+  region2DepthName: string;
+
+  /**
+   *  지역 3 Depth, 동 단위
+   */
+  region3DepthName: string;
+
+  /**
+   *  지역 3 Depth, 행정동 명칭
+   */
+  region3DepthHName: string;
+
+  /**
+   *  산 여부, Y 또는 N
+   */
+  mountainYn: string;
+
+  /**
+   *  지번 주번지
+   */
+  mainAddressNo: string;
+
+  /**
+   *  지번 부번지, 없을 경우 빈 문자열("") 반환
+   */
+  subAddressNo: string;
+
+  /**
+   * 우편번호(6자리)
+   * @deprecated
+   * @see [주소 검색 API의 우편번호 및 오탈자 응답 필드 제거 안내] https://devtalk.kakao.com/t/api-6/93000
+   */
+  deprecatedZipCode: string;
+}
+
+/**
+ * 도로명 주소 상세 정보
+ * @docs https://developers.kakao.com/docs/latest/ko/local/dev-guide#coord-to-address-response-body-road-address
+ */
+export interface RoadAddress {
+  /**
+   * 전체 도로명 주소
+   */
+  addressName: string;
+
+  /**
+   * 지역명1
+   */
+  region1DepthName: string;
+
+  /**
+   * 지역명2
+   */
+  region2DepthName: string;
+
+  /**
+   * 지역명3
+   */
+  region3DepthName: string;
+
+  /**
+   * 도로명
+   */
+  roadName: string;
+
+  /**
+   * 지하 여부, Y 또는 N
+   */
+  undergroundYn: 'Y' | 'N';
+
+  /**
+   * 건물 본번
+   */
+  mainBuildingNo: string;
+
+  /**
+   * 건물 부번, 없을 경우 빈 문자열("") 반환
+   */
+  subBuildingNo: string;
+
+  /**
+   * 건물 이름
+   */
+  buildingName: string;
+
+  /**
+   * 우편번호(5자리)
+   */
+  zoneNo: string;
+}

--- a/src/entity/enum/coord-type.enum.ts
+++ b/src/entity/enum/coord-type.enum.ts
@@ -2,7 +2,7 @@
  * 좌표계 타입
  */
 export enum CoordType {
-  /** 위경도 좌표계 */
+  /** 위경도 좌표계(GPS가 사용하는 좌표계) */
   WGS84 = 'WGS84',
   WCONGNAMUL = 'WCONGNAMUL',
   CONGNAMUL = 'CONGNAMUL',

--- a/src/entity/enum/coord-type.enum.ts
+++ b/src/entity/enum/coord-type.enum.ts
@@ -1,0 +1,12 @@
+/**
+ * 좌표계 타입
+ */
+export enum CoordType {
+  /** 위경도 좌표계 */
+  WGS84 = 'WGS84',
+  WCONGNAMUL = 'WCONGNAMUL',
+  CONGNAMUL = 'CONGNAMUL',
+  WGS84GEO = 'WGS84GEO',
+  WCONGNAMULGEO = 'WCONGNAMULGEO',
+  CONGNAMULGEO = 'CONGNAMULGEO',
+}

--- a/src/entity/enum/index.ts
+++ b/src/entity/enum/index.ts
@@ -1,3 +1,4 @@
 export * from './mbti-type.enum';
 export * from './recommend-type.enum';
 export * from './coord-type.enum';
+export * from './region-type.enum';

--- a/src/entity/enum/index.ts
+++ b/src/entity/enum/index.ts
@@ -1,0 +1,3 @@
+export * from './mbti-type.enum';
+export * from './recommend-type.enum';
+export * from './coord-type.enum';

--- a/src/entity/enum/mbti-type.enum.ts
+++ b/src/entity/enum/mbti-type.enum.ts
@@ -1,0 +1,21 @@
+/**
+ * Mbti 타입
+ */
+export enum MbtiType {
+  ISTJ = 'ISTJ',
+  ISFJ = 'ISFJ',
+  INFJ = 'INFJ',
+  INTJ = 'INTJ',
+  ISTP = 'ISTP',
+  ISFP = 'ISFP',
+  INFP = 'INFP',
+  INTP = 'INTP',
+  ESTP = 'ESTP',
+  ESFP = 'ESFP',
+  ENFP = 'ENFP',
+  ENTP = 'ENTP',
+  ESTJ = 'ESTJ',
+  ESFJ = 'ESFJ',
+  ENFJ = 'ENFJ',
+  ENTJ = 'ENTJ',
+}

--- a/src/entity/enum/recommend-type.enum.ts
+++ b/src/entity/enum/recommend-type.enum.ts
@@ -1,0 +1,7 @@
+/**
+ * 추천 타입
+ */
+export enum RecommendType {
+  RECOMMEND = 'Recommend',
+  UNRECOMMEND = 'Unrecommend',
+}

--- a/src/entity/enum/region-type.enum.ts
+++ b/src/entity/enum/region-type.enum.ts
@@ -1,0 +1,7 @@
+export enum RegionType {
+  /** H(행정동) */
+  H = 'H',
+
+  /** B(법정동) */
+  B = 'B',
+}

--- a/src/entity/feed/comment.entity.ts
+++ b/src/entity/feed/comment.entity.ts
@@ -1,6 +1,6 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { Expose } from 'class-transformer';
-import { Column, Entity } from 'typeorm';
+import { ApiHideProperty, ApiProperty } from '@nestjs/swagger';
+import { Exclude, Expose } from 'class-transformer';
+import { Column, Entity, ManyToOne } from 'typeorm';
 
 import { StringValidator } from '@app/common';
 import { Timestamp } from '../timestamp.entity';
@@ -26,6 +26,19 @@ export class Comment extends Timestamp {
   content: string;
 
   /* ========== 연관관계 ==========*/
+  @ApiHideProperty()
+  @Exclude()
+  @ManyToOne(() => User, (user) => user.comments, {
+    nullable: false,
+  })
   user: User;
+
+  @ApiHideProperty()
+  @Exclude()
+  @ManyToOne(() => Feed, (feed) => feed.comments, {
+    nullable: false,
+    onDelete: 'CASCADE',
+    // Note: 연관관계 주인인 피드가 삭제되면 댓글도 삭제된다.
+  })
   feed: Feed;
 }

--- a/src/entity/feed/comment.entity.ts
+++ b/src/entity/feed/comment.entity.ts
@@ -1,0 +1,16 @@
+import { Timestamp } from '../timestamp.entity';
+import { User } from '../user';
+import { Feed } from './feed.entity';
+
+export class Comment extends Timestamp {
+  /**
+   * 댓글 내용
+   * - 140자
+   * - 3byte * 140
+   */
+  content: string;
+
+  /* ========== 연관관계 ==========*/
+  user: User;
+  feed: Feed;
+}

--- a/src/entity/feed/comment.entity.ts
+++ b/src/entity/feed/comment.entity.ts
@@ -1,13 +1,28 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Expose } from 'class-transformer';
+import { Column, Entity } from 'typeorm';
+
+import { StringValidator } from '@app/common';
 import { Timestamp } from '../timestamp.entity';
 import { User } from '../user';
 import { Feed } from './feed.entity';
 
+@Entity('comment')
 export class Comment extends Timestamp {
   /**
    * 댓글 내용
    * - 140자
    * - 3byte * 140
    */
+  @ApiProperty({
+    description: '댓글 내용',
+    type: String,
+    minLength: 3,
+    maxLength: 420,
+  })
+  @Expose()
+  @StringValidator({ minLength: 3, maxLength: 420 })
+  @Column('varchar', { comment: '댓글 내용', length: 420 })
   content: string;
 
   /* ========== 연관관계 ==========*/

--- a/src/entity/feed/feed.entity.ts
+++ b/src/entity/feed/feed.entity.ts
@@ -1,3 +1,8 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Column, Entity } from 'typeorm';
+import { Expose } from 'class-transformer';
+
+import { BooleanValidator, IntValidator, StringValidator } from '@app/common';
 import { GeoMark } from '../geo';
 import { Timestamp } from '../timestamp.entity';
 import { User } from '../user';
@@ -5,20 +10,40 @@ import { Comment } from './comment.entity';
 import { RecommendHistory } from './recommend-history.entity';
 import { ReportHistory } from './report-history.entity';
 
+@Entity('feed')
 export class Feed extends Timestamp {
   /**
    * 피드 활성도
    * - 1 ~ 5
    * - default 1
    */
+  @ApiProperty({
+    description: '피드 활성도',
+    type: Number,
+    minimum: 1,
+    maximum: 5,
+    default: 1,
+  })
+  @Expose()
+  @IntValidator({ min: 1, max: 5 })
+  @Column('smallint', { comment: '피드 활성도', default: 1 })
   activity: number;
 
   /**
    * 피드 내용
    * - 140자
-   * - 3byte * 140
+   * - 3byte * 140 = 420
    */
-  content: string; // 140자 > 3byte * 140 하면될까?
+  @ApiProperty({
+    description: '피드 내용',
+    type: String,
+    minLength: 3,
+    maxLength: 420,
+  })
+  @Expose()
+  @StringValidator({ minLength: 3, maxLength: 420 })
+  @Column('varchar', { comment: '피드 내용', length: 420 })
+  content: string;
 
   /**
    * 썸네일 이미지 리스트
@@ -26,7 +51,20 @@ export class Feed extends Timestamp {
    * - max 5
    * - default []
    */
-  thumbnailImages: string[];
+  @ApiProperty({
+    description: '썸네일 이미지 리스트',
+    type: [String],
+    minItems: 0,
+    maxItems: 5,
+  })
+  @Expose()
+  @StringValidator({ arrayMinSize: 0, arrayMaxSize: 5 }, { each: true })
+  @Column('text', {
+    comment: '썸네일 이미지 리스트',
+    array: true,
+    default: '{}',
+  })
+  thumbnailImages: string[] | [];
 
   /**
    * 이미지 리스트
@@ -34,41 +72,85 @@ export class Feed extends Timestamp {
    * - max 5
    * - default []
    */
-  images: string[];
+  @ApiProperty({
+    description: '이미지 리스트',
+    type: [String],
+    minItems: 0,
+    maxItems: 5,
+  })
+  @Expose()
+  @StringValidator({ arrayMinSize: 0, arrayMaxSize: 5 }, { each: true })
+  @Column('text', {
+    comment: '이미지 리스트',
+    array: true,
+    default: '{}',
+  })
+  images: string[] | [];
+
   /**
    * 해시태그 리스트
    * - default []
    */
-  hashTags: string[];
+  @ApiProperty({ description: '해시태그 리스트', type: [String] })
+  @Expose()
+  @StringValidator({}, { each: true })
+  @Column('text', {
+    comment: '해시태그 리스트',
+    array: true,
+    default: '{}',
+  })
+  hashTags: string[] | [];
+
   /**
    * 피드 활성화 여부
    * - default true
+   * - 피드 남은 시간 0 이하면 false
+   * - 피드 남은 시간 = 생성된 시간 + (추천수 * 30) - (비추천 * 15)
    */
+  @ApiProperty({ description: '피드 활성화 여부', type: Boolean })
+  @Expose()
+  @BooleanValidator()
+  @Column('boolean', { comment: '피드 활성화 여부', default: true })
   isActive: boolean;
 
-  // 피드 남은 시간 = 생성된 시간 + (추천수 * 30) - (비추천 * 15)
   /**
    * 추천수
    * - default 0
    */
-  recommendCount: number; // 추천수, default 0
+  @ApiProperty({ description: '추천수', type: Number })
+  @Expose()
+  @IntValidator({ min: 0 })
+  @Column('integer', { comment: '추천수', default: 0 })
+  recommendCount: number;
 
   /**
    * 비추천수
    * - default 0
    */
+  @ApiProperty({ description: '비추천수', type: Number })
+  @Expose()
+  @IntValidator({ min: 0 })
+  @Column('integer', { comment: '비추천수', default: 0 })
   unrecommendCount: number;
 
   /**
    * 신고수
    * - default 0
    */
-  reportCount: number; // 신고수, default 0
+  @ApiProperty({ description: '신고수', type: Number })
+  @Expose()
+  @IntValidator({ min: 0 })
+  @Column('integer', { comment: '신고수', default: 0 })
+  reportCount: number;
 
   /**
-   * 노출수
+   * 조회수
    * - default 0
    */
+  @ApiProperty({ description: '조회수', type: Number })
+  @Expose()
+  @IntValidator({ min: 0 })
+  @Column('integer', { comment: '조회수', default: 0 })
   view: number;
 
   /* ========== 연관관계 ==========*/

--- a/src/entity/feed/feed.entity.ts
+++ b/src/entity/feed/feed.entity.ts
@@ -1,6 +1,13 @@
 import { ApiHideProperty, ApiProperty } from '@nestjs/swagger';
 import { Exclude, Expose } from 'class-transformer';
-import { Column, Entity, ManyToOne, OneToMany } from 'typeorm';
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  OneToMany,
+  OneToOne,
+} from 'typeorm';
 
 import { BooleanValidator, IntValidator, StringValidator } from '@app/common';
 import { GeoMark } from '../geo';
@@ -176,6 +183,15 @@ export class Feed extends Timestamp {
   })
   recommendHistories: RecommendHistory[] | [];
 
+  /**
+   * 위치 정보
+   * - 연관관계 주인은 피드이다.
+   * @JoinColumn
+   */
+  @ApiHideProperty()
+  @Exclude()
+  @OneToOne(() => GeoMark)
+  @JoinColumn()
   geoMark: GeoMark;
 
   /* ========== 단순 연관관계 - 조회 가능 ==========*/

--- a/src/entity/feed/feed.entity.ts
+++ b/src/entity/feed/feed.entity.ts
@@ -1,6 +1,6 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { Column, Entity } from 'typeorm';
-import { Expose } from 'class-transformer';
+import { ApiHideProperty, ApiProperty } from '@nestjs/swagger';
+import { Exclude, Expose } from 'class-transformer';
+import { Column, Entity, ManyToOne, OneToMany } from 'typeorm';
 
 import { BooleanValidator, IntValidator, StringValidator } from '@app/common';
 import { GeoMark } from '../geo';
@@ -153,10 +153,51 @@ export class Feed extends Timestamp {
   @Column('integer', { comment: '조회수', default: 0 })
   view: number;
 
-  /* ========== 연관관계 ==========*/
-  user: User;
-  geoMark: GeoMark;
+  /* ========== 연관관계 주인 ==========*/
+  /**
+   * 피드에 달린 댓글 리스트
+   */
+  @ApiHideProperty()
+  @Exclude()
+  @OneToMany(() => Comment, (comment) => comment.feed, {
+    nullable: true,
+    cascade: true,
+  })
   comments: Comment[] | [];
+
+  /**
+   * 피드에 추천, 비추천 내역
+   */
+  @ApiHideProperty()
+  @Exclude()
+  @OneToMany(() => RecommendHistory, (history) => history.feed, {
+    nullable: true,
+    cascade: true,
+  })
   recommendHistories: RecommendHistory[] | [];
+
+  geoMark: GeoMark;
+
+  /* ========== 단순 연관관계 - 조회 가능 ==========*/
+
+  /**
+   * 피드에 신고 내역
+   * - 피드가 지워저도 신고 내역은 남아있는다.
+   */
+  @ApiHideProperty()
+  @Exclude()
+  @OneToMany(() => ReportHistory, (history) => history.feed, {
+    nullable: true,
+  })
   reportHistories: ReportHistory[] | [];
+
+  /**
+   * 작성자
+   */
+  @ApiHideProperty()
+  @Exclude()
+  @ManyToOne(() => User, (user) => user.feeds, {
+    nullable: false,
+  })
+  user: User;
 }

--- a/src/entity/feed/feed.entity.ts
+++ b/src/entity/feed/feed.entity.ts
@@ -1,0 +1,80 @@
+import { GeoMark } from '../geo';
+import { Timestamp } from '../timestamp.entity';
+import { User } from '../user';
+import { Comment } from './comment.entity';
+import { RecommendHistory } from './recommend-history.entity';
+import { ReportHistory } from './report-history.entity';
+
+export class Feed extends Timestamp {
+  /**
+   * 피드 활성도
+   * - 1 ~ 5
+   * - default 1
+   */
+  activity: number;
+
+  /**
+   * 피드 내용
+   * - 140자
+   * - 3byte * 140
+   */
+  content: string; // 140자 > 3byte * 140 하면될까?
+
+  /**
+   * 썸네일 이미지 리스트
+   * - min 0
+   * - max 5
+   * - default []
+   */
+  thumbnailImages: string[];
+
+  /**
+   * 이미지 리스트
+   * - min 0
+   * - max 5
+   * - default []
+   */
+  images: string[];
+  /**
+   * 해시태그 리스트
+   * - default []
+   */
+  hashTags: string[];
+  /**
+   * 피드 활성화 여부
+   * - default true
+   */
+  isActive: boolean;
+
+  // 피드 남은 시간 = 생성된 시간 + (추천수 * 30) - (비추천 * 15)
+  /**
+   * 추천수
+   * - default 0
+   */
+  recommendCount: number; // 추천수, default 0
+
+  /**
+   * 비추천수
+   * - default 0
+   */
+  unrecommendCount: number;
+
+  /**
+   * 신고수
+   * - default 0
+   */
+  reportCount: number; // 신고수, default 0
+
+  /**
+   * 노출수
+   * - default 0
+   */
+  view: number;
+
+  /* ========== 연관관계 ==========*/
+  user: User;
+  geoMark: GeoMark;
+  comments: Comment[] | [];
+  recommendHistories: RecommendHistory[] | [];
+  reportHistories: ReportHistory[] | [];
+}

--- a/src/entity/feed/index.ts
+++ b/src/entity/feed/index.ts
@@ -1,0 +1,4 @@
+export * from './feed.entity';
+export * from './comment.entity';
+export * from './recommend-history.entity';
+export * from './report-history.entity';

--- a/src/entity/feed/recommend-history.entity.ts
+++ b/src/entity/feed/recommend-history.entity.ts
@@ -1,13 +1,26 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Expose } from 'class-transformer';
+import { Column, Entity } from 'typeorm';
+
+import { EnumValidator } from '@app/common';
 import { RecommendType } from '../enum';
 import { Timestamp } from '../timestamp.entity';
 import { User } from '../user';
 import { Feed } from './feed.entity';
 
+@Entity('recommend_history')
 export class RecommendHistory extends Timestamp {
   /**
    * 추천 타입
    * - 'Recommend' | 'Unrecommend'
    */
+  @ApiProperty({
+    description: 'MBTI 유형',
+    enum: RecommendType,
+  })
+  @Expose()
+  @EnumValidator(RecommendType)
+  @Column('enum', { enum: RecommendType, comment: 'MBTI 유형' })
   type: RecommendType;
 
   /* ========== 연관관계 ==========*/

--- a/src/entity/feed/recommend-history.entity.ts
+++ b/src/entity/feed/recommend-history.entity.ts
@@ -1,6 +1,6 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { Expose } from 'class-transformer';
-import { Column, Entity } from 'typeorm';
+import { ApiHideProperty, ApiProperty } from '@nestjs/swagger';
+import { Exclude, Expose } from 'class-transformer';
+import { Column, Entity, ManyToOne } from 'typeorm';
 
 import { EnumValidator } from '@app/common';
 import { RecommendType } from '../enum';
@@ -23,7 +23,20 @@ export class RecommendHistory extends Timestamp {
   @Column('enum', { enum: RecommendType, comment: 'MBTI 유형' })
   type: RecommendType;
 
-  /* ========== 연관관계 ==========*/
+  /* ========== 단순 연관관계 - 역방향 x ==========*/
+  @ApiHideProperty()
+  @Exclude()
+  @ManyToOne(() => Feed, (feed) => feed.comments, {
+    nullable: false,
+    onDelete: 'CASCADE',
+    // Note: 연관관계 주인인 피드가 삭제되면 댓글도 삭제된다.
+  })
   feed: Feed; // 부모
+
+  @ApiHideProperty()
+  @Exclude()
+  @ManyToOne(() => User, (user) => user.recommendHistories, {
+    nullable: false,
+  })
   user: User;
 }

--- a/src/entity/feed/recommend-history.entity.ts
+++ b/src/entity/feed/recommend-history.entity.ts
@@ -1,0 +1,16 @@
+import { RecommendType } from '../enum';
+import { Timestamp } from '../timestamp.entity';
+import { User } from '../user';
+import { Feed } from './feed.entity';
+
+export class RecommendHistory extends Timestamp {
+  /**
+   * 추천 타입
+   * - 'Recommend' | 'Unrecommend'
+   */
+  type: RecommendType;
+
+  /* ========== 연관관계 ==========*/
+  feed: Feed; // 부모
+  user: User;
+}

--- a/src/entity/feed/report-history.entity.ts
+++ b/src/entity/feed/report-history.entity.ts
@@ -1,0 +1,14 @@
+import { User } from '@sentry/node';
+import { Timestamp } from '../timestamp.entity';
+import { Feed } from './feed.entity';
+
+export class ReportHistory extends Timestamp {
+  /**
+   * 신고 사유
+   */
+  reason: string;
+
+  /* ========== 연관관계 ==========*/
+  feed: Feed; // 부모
+  user: User;
+}

--- a/src/entity/feed/report-history.entity.ts
+++ b/src/entity/feed/report-history.entity.ts
@@ -1,11 +1,26 @@
-import { User } from '@sentry/node';
+import { ApiProperty } from '@nestjs/swagger';
+import { Expose } from 'class-transformer';
+import { Column, Entity } from 'typeorm';
+
+import { StringValidator } from '@app/common';
 import { Timestamp } from '../timestamp.entity';
 import { Feed } from './feed.entity';
+import { User } from '../user';
 
+@Entity('report_history')
 export class ReportHistory extends Timestamp {
   /**
    * 신고 사유
    */
+  @ApiProperty({
+    description: '신고 사유',
+    type: String,
+    minLength: 10,
+    maxLength: 200,
+  })
+  @Expose()
+  @StringValidator({ minLength: 10, maxLength: 200 })
+  @Column('varchar', { comment: '신고 사유', length: 200 })
   reason: string;
 
   /* ========== 연관관계 ==========*/

--- a/src/entity/feed/report-history.entity.ts
+++ b/src/entity/feed/report-history.entity.ts
@@ -1,6 +1,6 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { Expose } from 'class-transformer';
-import { Column, Entity } from 'typeorm';
+import { ApiHideProperty, ApiProperty } from '@nestjs/swagger';
+import { Exclude, Expose } from 'class-transformer';
+import { Column, Entity, ManyToOne } from 'typeorm';
 
 import { StringValidator } from '@app/common';
 import { Timestamp } from '../timestamp.entity';
@@ -24,6 +24,23 @@ export class ReportHistory extends Timestamp {
   reason: string;
 
   /* ========== 연관관계 ==========*/
-  feed: Feed; // 부모
+  /**
+   * 피드
+   * - 피드가 삭제되도 신고 내역은 남아있는다.
+   */
+  @ApiHideProperty()
+  @Exclude()
+  @ManyToOne(() => Feed, (feed) => feed.comments, {
+    nullable: false,
+    orphanedRowAction: 'nullify',
+    onDelete: 'SET NULL',
+  })
+  feed: Feed;
+
+  @ApiHideProperty()
+  @Exclude()
+  @ManyToOne(() => User, (user) => user.recommendHistories, {
+    nullable: false,
+  })
   user: User;
 }

--- a/src/entity/geo/address.entity.ts
+++ b/src/entity/geo/address.entity.ts
@@ -1,3 +1,92 @@
-import { Timestamp } from '../timestamp.entity';
+import { ApiProperty } from '@nestjs/swagger';
+import { Column, Entity } from 'typeorm';
+import { Expose } from 'class-transformer';
 
-export class Address extends Timestamp {}
+import { StringValidator } from '@app/common';
+import { Timestamp } from '../timestamp.entity';
+import { GeoMark } from './geo-mark.entity';
+
+/**
+ * 지번 주소 상세 정보
+ * @docs https://developers.kakao.com/docs/latest/ko/local/dev-guide#coord-to-address-response-body-address
+ */
+@Entity('address')
+export class Address extends Timestamp {
+  /**
+   * 전체 지번 주소
+   */
+  @ApiProperty({ description: '전체 지번 주소', type: String })
+  @Expose()
+  @StringValidator()
+  @Column('varchar', { comment: '전체 지번 주소' })
+  addressName: string;
+
+  /**
+   * 지역 1 Depth, 시도 단위
+   */
+  @ApiProperty({ description: '지역 1 Depth, 시도 단위', type: String })
+  @Expose()
+  @StringValidator()
+  @Column('varchar', { comment: '지역 1 Depth, 시도 단위' })
+  region1DepthName: string;
+
+  /**
+   * 지역 2 Depth, 구 단위
+   */
+  @ApiProperty({ description: '지역 2 Depth, 시도 단위', type: String })
+  @Expose()
+  @StringValidator()
+  @Column('varchar', { comment: '지역 2 Depth, 시도 단위' })
+  region2DepthName: string;
+
+  /**
+   * 지역 3 Depth, 동 단위
+   */
+  @ApiProperty({ description: '지역 3 Depth, 동 단위', type: String })
+  @Expose()
+  @StringValidator()
+  @Column('varchar', { comment: '지역 3 Depth, 동 단위' })
+  region3DepthName: string;
+
+  /**
+   * 지역 3 Depth, 행정동 명칭
+   */
+  @ApiProperty({ description: '지역 3 Depth, 행정동 명칭', type: String })
+  @Expose()
+  @StringValidator()
+  @Column('varchar', { comment: '지역 3 Depth, 행정동 명칭' })
+  region3DepthHName: string;
+
+  /**
+   * 산 여부, Y 또는 N
+   */
+  @ApiProperty({ description: '산 여부, Y 또는 N', type: String })
+  @Expose()
+  @StringValidator()
+  @Column('char', { comment: '산 여부, Y 또는 N', length: 1 })
+  mountainYn: 'Y' | 'N';
+
+  /**
+   * 지번 주번지
+   */
+  @ApiProperty({ description: '지번 주번지', type: String })
+  @Expose()
+  @StringValidator()
+  @Column('varchar', { comment: '지번 주번지' })
+  mainAddressNo: string;
+
+  /**
+   *  지번 부번지, 없을 경우 빈 문자열("") 반환
+   */
+  @ApiProperty({
+    description: '지번 부번지, 없을 경우 빈 문자열("") 반환',
+    type: String,
+  })
+  @Expose()
+  @StringValidator()
+  @Column('varchar', { comment: '지번 부번지, 없을 경우 빈 문자열("") 반환' })
+  subAddressNo: string;
+
+  /* ========== 연관관계 ==========*/
+  geoMark: GeoMark;
+}

--- a/src/entity/geo/address.entity.ts
+++ b/src/entity/geo/address.entity.ts
@@ -1,0 +1,3 @@
+import { Timestamp } from '../timestamp.entity';
+
+export class Address extends Timestamp {}

--- a/src/entity/geo/address.entity.ts
+++ b/src/entity/geo/address.entity.ts
@@ -1,6 +1,6 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { Column, Entity } from 'typeorm';
-import { Expose } from 'class-transformer';
+import { ApiHideProperty, ApiProperty } from '@nestjs/swagger';
+import { Column, Entity, OneToOne } from 'typeorm';
+import { Exclude, Expose } from 'class-transformer';
 
 import { StringValidator } from '@app/common';
 import { Timestamp } from '../timestamp.entity';
@@ -88,5 +88,12 @@ export class Address extends Timestamp {
   subAddressNo: string;
 
   /* ========== 연관관계 ==========*/
+  /**
+   * 마커
+   * - 연관관계 주인은 마커이다.
+   */
+  @ApiHideProperty()
+  @Exclude()
+  @OneToOne(() => GeoMark)
   geoMark: GeoMark;
 }

--- a/src/entity/geo/geo-mark.entity.ts
+++ b/src/entity/geo/geo-mark.entity.ts
@@ -1,0 +1,45 @@
+import { CoordType } from '../enum';
+import { Feed } from '../feed';
+import { Timestamp } from '../timestamp.entity';
+import { Address } from './address.entity';
+import { RegionInfo } from './region-info.entity';
+import { RoadAddress } from './road-address.entity';
+
+export class GeoMark extends Timestamp {
+  /**
+   * 경도
+   * - Double
+   * - x = longtitue = 경도
+   */
+  x: number;
+  /**
+   * 위도
+   * - Double
+   * - y = lattitue = 위도
+   */
+  y: number;
+  /**
+   * 좌표계 타입
+   * - default 'WGS84'
+   */
+  type: CoordType;
+
+  /**
+   * 행정구역 정보
+   */
+  regionInfo: RegionInfo;
+
+  /**
+   * 주소 정보
+   */
+  address: Address;
+
+  /**
+   * 도로명 주소 정보
+   */
+  roadAddress?: RoadAddress | null;
+
+  /* ========== 연관관계 ==========*/
+  // 관계
+  feed: Feed;
+}

--- a/src/entity/geo/geo-mark.entity.ts
+++ b/src/entity/geo/geo-mark.entity.ts
@@ -1,3 +1,8 @@
+import { Column, Entity, Point } from 'typeorm';
+
+import { EnumValidator, NumberValidator } from '@app/common';
+import { ApiProperty } from '@nestjs/swagger';
+import { Exclude, Expose } from 'class-transformer';
 import { CoordType } from '../enum';
 import { Feed } from '../feed';
 import { Timestamp } from '../timestamp.entity';
@@ -5,24 +10,71 @@ import { Address } from './address.entity';
 import { RegionInfo } from './region-info.entity';
 import { RoadAddress } from './road-address.entity';
 
+@Entity('geo_mark')
 export class GeoMark extends Timestamp {
   /**
-   * 경도
+   * 경도(x좌표)
    * - Double
    * - x = longtitue = 경도
+   * - 대한민국 x축 범위: 33 ~ 43
    */
+  @ApiProperty({
+    description: '경도(x좌표)',
+    type: Number,
+    minimum: 0,
+  })
+  @Expose()
+  @NumberValidator({ min: 0 })
+  @Column('decimal', { comment: '경도(x좌표)' })
   x: number;
   /**
-   * 위도
+   * 위도(y좌표)
    * - Double
    * - y = lattitue = 위도
+   * - 대한민국 y축 범위: 124 ~ 132
    */
+  @ApiProperty({
+    description: '경위도(y좌표)',
+    type: Number,
+    minimum: 0,
+  })
+  @Expose()
+  @NumberValidator({ min: 0 })
+  @Column('decimal', { comment: '경위도(y좌표)' })
   y: number;
+
   /**
    * 좌표계 타입
    * - default 'WGS84'
    */
+  @ApiProperty({
+    description: '좌표계 타입',
+    enum: CoordType,
+  })
+  @Expose()
+  @EnumValidator(CoordType)
+  @Column('enum', { enum: CoordType, comment: '좌표계 타입', default: 'WGS84' })
   type: CoordType;
+
+  /**
+   * Postgis의 geometry 타입
+   * - point = POINT(x, y)
+   * - POINT()는 postgresql의 내장함수이다.
+   */
+  @Exclude()
+  @Column('geometry', { srid: 4326 })
+  point: Point;
+
+  /**
+   * SRID 식별자
+   * - SRID는 "Spatial Reference ID"의 약자로, 공간 데이터를 정의하는 데 사용되는 고유한 식별자이다.
+   * - WGS84 기준으로 대한민국은 EPSG 코드는 4326이다.
+   * - WGS84 좌표계가 GPS가 사용하는 좌표계이다.
+   * - Postgrsql의 Geometry 함수에는 SRID를 사용해야 정확한 값이 나온다.
+   */
+  @Exclude()
+  @Column('smallint', { comment: 'SRID 식별자', default: 4326 })
+  srid: 4326 | number;
 
   /**
    * 행정구역 정보

--- a/src/entity/geo/geo-mark.entity.ts
+++ b/src/entity/geo/geo-mark.entity.ts
@@ -1,8 +1,8 @@
-import { Column, Entity, Point } from 'typeorm';
+import { ApiHideProperty, ApiProperty } from '@nestjs/swagger';
+import { Exclude, Expose } from 'class-transformer';
+import { Column, Entity, JoinColumn, OneToOne, Point } from 'typeorm';
 
 import { EnumValidator, NumberValidator } from '@app/common';
-import { ApiProperty } from '@nestjs/swagger';
-import { Exclude, Expose } from 'class-transformer';
 import { CoordType } from '../enum';
 import { Feed } from '../feed';
 import { Timestamp } from '../timestamp.entity';
@@ -78,20 +78,45 @@ export class GeoMark extends Timestamp {
 
   /**
    * 행정구역 정보
+   * - 연관관계 주인은 마커이다.
+   * @JoinColumn
    */
+  @ApiHideProperty()
+  @Exclude()
+  @OneToOne(() => RegionInfo, { cascade: true })
+  @JoinColumn()
   regionInfo: RegionInfo;
 
   /**
-   * 주소 정보
+   * 주소 정보(구)
+   * - 연관관계 주인은 마커이다.
+   * @JoinColumn
    */
+  @ApiHideProperty()
+  @Exclude()
+  @OneToOne(() => Address, { cascade: true })
+  @JoinColumn()
   address: Address;
 
   /**
    * 도로명 주소 정보
+   * - 연관관계 주인은 마커이다.
+   * - 도로명 주소는 없을 수도 있다.
+   * @JoinColumn
    */
+  @ApiHideProperty()
+  @Exclude()
+  @OneToOne(() => RoadAddress, { cascade: true, nullable: true })
+  @JoinColumn()
   roadAddress?: RoadAddress | null;
 
   /* ========== 연관관계 ==========*/
-  // 관계
+  /**
+   * 피드
+   * - 연관관계 주인은 피드이다.
+   */
+  @ApiHideProperty()
+  @Exclude()
+  @OneToOne(() => Feed)
   feed: Feed;
 }

--- a/src/entity/geo/index.ts
+++ b/src/entity/geo/index.ts
@@ -1,0 +1,4 @@
+export * from './geo-mark.entity';
+export * from './region-info.entity';
+export * from './address.entity';
+export * from './road-address.entity';

--- a/src/entity/geo/region-info.entity.ts
+++ b/src/entity/geo/region-info.entity.ts
@@ -1,3 +1,115 @@
-import { Timestamp } from '../timestamp.entity';
+import { ApiProperty } from '@nestjs/swagger';
+import { Expose } from 'class-transformer';
+import { Column, Entity } from 'typeorm';
 
-export class RegionInfo extends Timestamp {}
+import { EnumValidator, StringValidator } from '@app/common';
+import { RegionType } from '../enum';
+import { Timestamp } from '../timestamp.entity';
+import { GeoMark } from './geo-mark.entity';
+
+/**
+ * 좌표로 행정구역정보 받기
+ * @docs https://developers.kakao.com/docs/latest/ko/local/dev-guide#coord-to-district-response-body-document
+ */
+@Entity('region_info')
+export class RegionInfo extends Timestamp {
+  /**
+   * H(행정동) 또는 B(법정동)
+   */
+  @ApiProperty({
+    description: 'H(행정동) 또는 B(법정동)',
+    enum: RegionType,
+  })
+  @Expose()
+  @EnumValidator(RegionType)
+  @Column('enum', { enum: RegionType, comment: 'H(행정동) 또는 B(법정동)' })
+  regionType: RegionType;
+
+  /**
+   * 전체 지역 명칭
+   */
+  @ApiProperty({ description: '전체 지역 명칭', type: String })
+  @Expose()
+  @StringValidator()
+  @Column('varchar', { comment: '전체 지역 명칭' })
+  addressName: string;
+
+  /**
+   * 지역 1Depth, 시도 단위 바다 영역은 존재하지 않음
+   */
+  @ApiProperty({
+    description: '지역 1Depth, 시도 단위 바다 영역은 존재하지 않음',
+    type: String,
+  })
+  @Expose()
+  @StringValidator()
+  @Column('varchar', {
+    comment: '지역 1Depth, 시도 단위 바다 영역은 존재하지 않음',
+  })
+  region1DepthName: string;
+
+  /**
+   * 지역 2Depth, 구 단위 바다 영역은 존재하지 않음
+   */
+  @ApiProperty({
+    description: '지역 2Depth, 구 단위 바다 영역은 존재하지 않음',
+    type: String,
+  })
+  @Expose()
+  @StringValidator()
+  @Column('varchar', {
+    comment: '지역 2Depth, 구 단위 바다 영역은 존재하지 않음',
+  })
+  region2DepthName: string;
+
+  /**
+   * 지역 3Depth, 동 단위 바다 영역은 존재하지 않음
+   */
+  @ApiProperty({
+    description: '지역 3Depth, 동 단위 바다 영역은 존재하지 않음',
+    type: String,
+  })
+  @Expose()
+  @StringValidator()
+  @Column('varchar', {
+    comment: '지역 3Depth, 동 단위 바다 영역은 존재하지 않음',
+  })
+  region3DepthName: string;
+
+  /**
+   * 지역 4Depth, 리 영역인 경우만 존재 regionType이 법정동이며;
+   */
+  @ApiProperty({
+    description: '지역 4Depth, 리 영역인 경우만 존재 regionType이 법정동이며;',
+    type: String,
+  })
+  @Expose()
+  @StringValidator()
+  @Column('varchar', {
+    comment: '지역 4Depth, 리 영역인 경우만 존재 regionType이 법정동이며;',
+  })
+  region4DepthName: string;
+
+  /**
+   * region 코드
+   */
+  @ApiProperty({ description: 'region 코드', type: String })
+  @Expose()
+  @StringValidator()
+  @Column('varchar', { comment: 'region 코드' })
+  code: string;
+
+  /**
+   * X 좌표값, 경위도인 경우 경도(longitude)
+   * - Double
+   */
+  x: number;
+  /**
+   * Y 좌표값, 경위도인 경우 위도(latitude)
+   * - Double
+   */
+  y: number;
+
+  /* ========== 연관관계 ==========*/
+  geoMark: GeoMark;
+}

--- a/src/entity/geo/region-info.entity.ts
+++ b/src/entity/geo/region-info.entity.ts
@@ -1,6 +1,6 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { Expose } from 'class-transformer';
-import { Column, Entity } from 'typeorm';
+import { ApiHideProperty, ApiProperty } from '@nestjs/swagger';
+import { Exclude, Expose } from 'class-transformer';
+import { Column, Entity, OneToOne } from 'typeorm';
 
 import { EnumValidator, StringValidator } from '@app/common';
 import { RegionType } from '../enum';
@@ -111,5 +111,12 @@ export class RegionInfo extends Timestamp {
   y: number;
 
   /* ========== 연관관계 ==========*/
+  /**
+   * 마커
+   * - 연관관계 주인은 마커이다.
+   */
+  @ApiHideProperty()
+  @Exclude()
+  @OneToOne(() => GeoMark)
   geoMark: GeoMark;
 }

--- a/src/entity/geo/region-info.entity.ts
+++ b/src/entity/geo/region-info.entity.ts
@@ -1,0 +1,3 @@
+import { Timestamp } from '../timestamp.entity';
+
+export class RegionInfo extends Timestamp {}

--- a/src/entity/geo/road-address.entity.ts
+++ b/src/entity/geo/road-address.entity.ts
@@ -1,3 +1,110 @@
-import { Timestamp } from '../timestamp.entity';
+import { ApiProperty } from '@nestjs/swagger';
+import { Expose } from 'class-transformer';
+import { Column, Entity } from 'typeorm';
 
-export class RoadAddress extends Timestamp {}
+import { StringValidator } from '@app/common';
+import { Timestamp } from '../timestamp.entity';
+import { GeoMark } from './geo-mark.entity';
+
+/**
+ * 도로명 주소 상세 정보
+ * @docs https://developers.kakao.com/docs/latest/ko/local/dev-guide#coord-to-address-response-body-road-address
+ */
+@Entity('road_address')
+export class RoadAddress extends Timestamp {
+  /**
+   * 전체 도로명 주소
+   */
+  @ApiProperty({ description: '전체 도로명 주소', type: String })
+  @Expose()
+  @StringValidator()
+  @Column('varchar', { comment: '전체 도로명 주소' })
+  addressName: string;
+
+  /**
+   * 지역명1
+   */
+  @ApiProperty({ description: '지역명1', type: String })
+  @Expose()
+  @StringValidator()
+  @Column('varchar', { comment: '지역명1' })
+  region1DepthName: string;
+
+  /**
+   * 지역명2
+   */
+  @ApiProperty({ description: '지역명2', type: String })
+  @Expose()
+  @StringValidator()
+  @Column('varchar', { comment: '지역명2' })
+  region2DepthName: string;
+
+  /**
+   * 지역명3
+   */
+  @ApiProperty({ description: '지역명3', type: String })
+  @Expose()
+  @StringValidator()
+  @Column('varchar', { comment: '지역명3' })
+  region3DepthName: string;
+
+  /**
+   * 도로명
+   */
+  @ApiProperty({ description: '도로명', type: String })
+  @Expose()
+  @StringValidator()
+  @Column('varchar', { comment: '도로명' })
+  roadName: string;
+
+  /**
+   * 지하 여부, Y 또는 N
+   */
+  @ApiProperty({ description: '지하 여부, Y 또는 N', type: String })
+  @Expose()
+  @StringValidator()
+  @Column('char', { comment: '지하 여부, Y 또는 N', length: 1 })
+  undergroundYn: 'Y' | 'N';
+
+  /**
+   * 건물 본번
+   */
+  @ApiProperty({ description: '건물 본번', type: String })
+  @Expose()
+  @StringValidator()
+  @Column('varchar', { comment: '건물 본번' })
+  mainBuildingNo: string;
+
+  /**
+   * 건물 부번, 없을 경우 빈 문자열("") 반환
+   */
+  @ApiProperty({
+    description: '건물 부번, 없을 경우 빈 문자열("") 반환',
+    type: String,
+  })
+  @Expose()
+  @StringValidator()
+  @Column('varchar', { comment: '건물 부번, 없을 경우 빈 문자열("") 반환' })
+  subBuildingNo: string;
+
+  /**
+   * 건물 이름
+   */
+  @ApiProperty({ description: '건물 이름', type: String })
+  @Expose()
+  @StringValidator()
+  @Column('varchar', { comment: '건물 이름' })
+  buildingName: string;
+
+  /**
+   * 우편번호(5자리)
+   */
+  @ApiProperty({ description: '우편번호(5자리)', type: String })
+  @Expose()
+  @StringValidator()
+  @Column('char', { comment: '우편번호(5자리)', length: 5 })
+  zoneNo: string;
+
+  /* ========== 연관관계 ==========*/
+  geoMark: GeoMark;
+}

--- a/src/entity/geo/road-address.entity.ts
+++ b/src/entity/geo/road-address.entity.ts
@@ -1,0 +1,3 @@
+import { Timestamp } from '../timestamp.entity';
+
+export class RoadAddress extends Timestamp {}

--- a/src/entity/geo/road-address.entity.ts
+++ b/src/entity/geo/road-address.entity.ts
@@ -1,6 +1,6 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { Expose } from 'class-transformer';
-import { Column, Entity } from 'typeorm';
+import { ApiHideProperty, ApiProperty } from '@nestjs/swagger';
+import { Exclude, Expose } from 'class-transformer';
+import { Column, Entity, OneToOne } from 'typeorm';
 
 import { StringValidator } from '@app/common';
 import { Timestamp } from '../timestamp.entity';
@@ -106,5 +106,12 @@ export class RoadAddress extends Timestamp {
   zoneNo: string;
 
   /* ========== 연관관계 ==========*/
+  /**
+   * 마커
+   * - 연관관계 주인은 마커이다.
+   */
+  @ApiHideProperty()
+  @Exclude()
+  @OneToOne(() => GeoMark)
   geoMark: GeoMark;
 }

--- a/src/entity/index.ts
+++ b/src/entity/index.ts
@@ -1,0 +1,4 @@
+export * from './user';
+export * from './feed';
+export * from './geo';
+export * from './enum';

--- a/src/entity/interface/entity.interface.ts
+++ b/src/entity/interface/entity.interface.ts
@@ -163,6 +163,26 @@ export interface Feed {
   user: User;
   geoMark: GeoMark;
   comments: Comment[] | [];
+  recommendHistories: RecommendHistory[] | [];
+  reportHistories: ReportHistory[] | [];
+}
+
+export interface Comment {
+  id: string;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt?: Date;
+
+  /**
+   * 댓글 내용
+   * - 140자
+   * - 3byte * 140
+   */
+  content: string;
+
+  /* ========== 연관관계 ==========*/
+  user: User;
+  feed: Feed;
 }
 
 export interface RecommendHistory {

--- a/src/entity/interface/entity.interface.ts
+++ b/src/entity/interface/entity.interface.ts
@@ -269,27 +269,27 @@ export interface RegionInfo {
   /**
    * H(행정동) 또는 B(법정동)
    */
-  region_type: string;
+  regionType: string;
   /**
    * 전체 지역 명칭
    */
-  address_name: string;
+  addressName: string;
   /**
    * 지역 1Depth, 시도 단위 바다 영역은 존재하지 않음
    */
-  region_1depth_name: string;
+  region1DepthName: string;
   /**
    * 지역 2Depth, 구 단위 바다 영역은 존재하지 않음
    */
-  region_2depth_name: string;
+  region2DepthName: string;
   /**
    * 지역 3Depth, 동 단위 바다 영역은 존재하지 않음
    */
-  region_3depth_name: string;
+  region3DepthName: string;
   /**
-   * 지역 4Depth, 리 영역인 경우만 존재 region_type이 법정동이며;
+   * 지역 4Depth, 리 영역인 경우만 존재 regionType이 법정동이며;
    */
-  region_4depth_name: string;
+  region4DepthName: string;
   /**
    * region 코드
    */

--- a/src/entity/user/index.ts
+++ b/src/entity/user/index.ts
@@ -1,0 +1,1 @@
+export * from './user.entity';

--- a/src/entity/user/user.entity.ts
+++ b/src/entity/user/user.entity.ts
@@ -1,11 +1,34 @@
-import { Timestamp } from '../timestamp.entity';
+import {
+  ApiHideProperty,
+  ApiProperty,
+  ApiPropertyOptional,
+} from '@nestjs/swagger';
+import { Exclude, Expose } from 'class-transformer';
+import { Column, Entity } from 'typeorm';
+
+import {
+  DateValidator,
+  DateValidatorOptional,
+  EnumValidator,
+  IntValidator,
+  StringValidator,
+} from '@app/common';
 import { MbtiType } from '../enum';
 import { Comment, Feed } from '../feed';
+import { Timestamp } from '../timestamp.entity';
 
+@Entity('user')
 export class User extends Timestamp {
   /**
    * MBTI 유형
    */
+  @ApiProperty({
+    description: 'MBTI 유형',
+    enum: MbtiType,
+  })
+  @Expose()
+  @EnumValidator(MbtiType)
+  @Column('enum', { enum: MbtiType, comment: 'MBTI 유형' })
   mbtiType: MbtiType;
 
   /**
@@ -13,12 +36,25 @@ export class User extends Timestamp {
    * - 000 + id,
    * - default 0000
    */
+  @ApiProperty({
+    description: '닉네임',
+    type: String,
+    default: '닉네임',
+    maxLength: 50,
+  })
+  @Expose()
+  @StringValidator({ maxLength: 50 })
+  @Column('varchar', { comment: '닉네임', length: 50, default: '0000' })
   nickname: string;
 
   /**
    * JWT 토큰
    * - defalt ''
    */
+  @ApiHideProperty()
+  @Exclude()
+  @StringValidator({ maxLength: 300 })
+  @Column('varchar', { comment: 'JWT 토큰', length: 300, default: '' })
   token: string;
 
   /**
@@ -26,19 +62,43 @@ export class User extends Timestamp {
    * - mvp에서는 생성시 추가
    * - default now
    */
+  @ApiHideProperty()
+  @Exclude()
+  @DateValidator()
+  @Column('timestamptz', { comment: '마지막 접속일', default: () => 'NOW()' })
   accessedAt: Date;
 
   /**
-   * 피드 작성 횟수
+   * 피드 작성 가능 횟수
    * - min 0
    * - max 5
    * - default 5
    */
+  @ApiProperty({
+    description: '피드 작성 가능 횟수',
+    type: Number,
+    minimum: 0,
+    maximum: 5,
+    default: 5,
+  })
+  @Expose()
+  @IntValidator({ min: 0, max: 5 })
+  @Column('smallint', { comment: '피드 작성 가능 횟수', default: 5 })
   feedWritingCount: number;
 
   /**
    * 피드 마지막 작성 시간 날짜
    */
+  @ApiPropertyOptional({
+    description: '피드 마지막 작성 시간 날짜',
+    type: Date,
+  })
+  @Expose()
+  @DateValidatorOptional()
+  @Column('timestamptz', {
+    comment: '피드 마지막 작성 시간 날짜',
+    nullable: true,
+  })
   lastFeedWrittenAt?: Date | null;
 
   /* ========== 연관관계 ==========*/

--- a/src/entity/user/user.entity.ts
+++ b/src/entity/user/user.entity.ts
@@ -1,0 +1,47 @@
+import { Timestamp } from '../timestamp.entity';
+import { MbtiType } from '../enum';
+import { Comment, Feed } from '../feed';
+
+export class User extends Timestamp {
+  /**
+   * MBTI 유형
+   */
+  mbtiType: MbtiType;
+
+  /**
+   * 닉네임
+   * - 000 + id,
+   * - default 0000
+   */
+  nickname: string;
+
+  /**
+   * JWT 토큰
+   * - defalt ''
+   */
+  token: string;
+
+  /**
+   * 마지막 접속일
+   * - mvp에서는 생성시 추가
+   * - default now
+   */
+  accessedAt: Date;
+
+  /**
+   * 피드 작성 횟수
+   * - min 0
+   * - max 5
+   * - default 5
+   */
+  feedWritingCount: number;
+
+  /**
+   * 피드 마지막 작성 시간 날짜
+   */
+  lastFeedWrittenAt?: Date | null;
+
+  /* ========== 연관관계 ==========*/
+  feeds: Feed[] | [];
+  comments: Comment[] | [];
+}

--- a/src/entity/user/user.entity.ts
+++ b/src/entity/user/user.entity.ts
@@ -4,7 +4,7 @@ import {
   ApiPropertyOptional,
 } from '@nestjs/swagger';
 import { Exclude, Expose } from 'class-transformer';
-import { Column, Entity } from 'typeorm';
+import { Column, Entity, OneToMany } from 'typeorm';
 
 import {
   DateValidator,
@@ -14,7 +14,7 @@ import {
   StringValidator,
 } from '@app/common';
 import { MbtiType } from '../enum';
-import { Comment, Feed } from '../feed';
+import { Comment, Feed, RecommendHistory, ReportHistory } from '../feed';
 import { Timestamp } from '../timestamp.entity';
 
 @Entity('user')
@@ -101,7 +101,49 @@ export class User extends Timestamp {
   })
   lastFeedWrittenAt?: Date | null;
 
-  /* ========== 연관관계 ==========*/
+  /* ========== 단순 연관관계 - 역방향 x ==========*/
+  /**
+   * 유저가 작성한 피드 내역
+   * - TODO: 유저가 삭제되면 피드도 삭제할까?
+   */
+  @ApiHideProperty()
+  @Exclude()
+  @OneToMany(() => Feed, (feed) => feed.user, {
+    nullable: true,
+    cascade: ['soft-remove'],
+  })
   feeds: Feed[] | [];
+
+  /**
+   * 유저가 작성한 댓글 내역
+   * - TODO: 유저가 삭제되면 댓글도 삭제할까?
+   */
+  @ApiHideProperty()
+  @Exclude()
+  @OneToMany(() => Comment, (comment) => comment.user, {
+    nullable: true,
+    cascade: ['soft-remove'],
+    // Note: 유저는 자신의 댓글 삭제에만 권한을 가진다, 연관관계 주인은 Feed이다.
+  })
   comments: Comment[] | [];
+
+  /**
+   * 유저 추천, 비추천 내역
+   */
+  @ApiHideProperty()
+  @Exclude()
+  @OneToMany(() => RecommendHistory, (history) => history.user, {
+    nullable: true,
+  })
+  recommendHistories: RecommendHistory[] | [];
+
+  /**
+   * 유저가 신고한 내역
+   */
+  @ApiHideProperty()
+  @Exclude()
+  @OneToMany(() => ReportHistory, (history) => history.user, {
+    nullable: true,
+  })
+  reportHistories: ReportHistory[] | [];
 }


### PR DESCRIPTION
# PR Summery

## [FEATURE]

![image](https://github.com/2023vworks/heat-it-be/assets/57210007/78f3edaf-ab16-4676-a2a5-ec42c7bde6f5)
- [Entity 정의 및 테이블 설계 ](https://www.notion.so/Entity-f03a61fec90240e98f34d563cb6ea655)

## [WORK-LOG]

### 1. 비즈니스 관계성 정의

- 유저는 지도에서 마크를 조회하여 피드를 조회할 수 있다. 
- 유저는 특정위치에 피드를 작성하여 마크를 생성할 수 있다.
- 유저는 피드에 댓글을 작성할 수 있다. 
- 유저는 피드에 추천, 비추천, 신고를 할 수 있다.

### 2. 지도 데이터 저장

![image](https://github.com/2023vworks/heat-it-be/assets/57210007/50a30a10-d463-4ae7-ae02-b1925b9c6ad6)
붐빔 MVP는 카카오 지도에서 데이터를 받아온다. 
그렇기에 최대한 카카오 지도 API에서 제공하는 데이터와 유사하게 엔티티를 설계하였다.
또한 어떤 데이터를 사용할지 현재 상황에서는 알 수 없기 때문에 최대한 많은 데이터를 저장 할 수 있도록 하였다

### 3. geo 연산

#### 고려사항
geo 데이터를 처음 다뤄보았기 때문에 활용법에 대해 최소한의 학습이 필요하였다. 고려해야하는 결과는 아래와 같다 
1. 위도, 경도는 소수점으로 오며 소수점 자리수는 고정적이지 않다.
2. 위도, 경도는 각각 y축과, x 축으로 치완되어 하나의 점을 가리키며 이것을 point 부르기도 한다.
3. 위도, 경도는 특정 좌표계에서만 유효하다. (즉, 좌표계가 다르면 위치가 맞지 않게 된다.)
4. 좌표계는 간단하게 어떠한 방식으로 좌표를 계산했는지 방법이다. (카카오 지도 디폴트는 WGS84으로 GPS 계산법을 사용한다.)
5. 위도, 경도를 DB 컬럼에 저장하기 위해서는 배정밀도의 부동소수점 컬럼을 사용해야 한다. (numeric) 컬럼
6. geo데이터의 계산은 결국 좌표에 대한 수학적인 계산이다. 
7. 현재 스펙에서는 직접적인 소수점 연산이 없지만 그래도 js에서 geo 연산을 하지 않기 위해 다른 솔루션을 찾아볼 필요가 있었다.
8. 결과적으로 우리가 사용하는 postgresql에서 geo 연산을 지원하는 "PosgGIS" 확장을 지원하는 것을 활용하기로 했다.

#### PosgGIS 검증과 지도 데이터 테스트

일딴 우리서비스에서 geo 연산이 필요한 것은 아래와 같다. 
- 특정 범위에 포함된 모든 마커를 조회한다.
- 특정 범위에 포함된 모든 피드를 조회한다. 
둘다 특정 좌표평면에 포함된 좌표(이하 point)를 조회하는 것이다. 

그리고 조회 방법은 크게 2가지가 있다.  
1. 소수점 비교를 통한 단순한 조회 
2. PosgGIS에서 지원하는 폴리곤에 포함된 좌표를 조회

폴리곤란?
![image](https://github.com/2023vworks/heat-it-be/assets/57210007/264365ab-ce90-4ea5-ba5e-4bb358f0ebe9)
- 이미지는 카카오 지도에서 지원하는 영역을 표시하는 기능이다. 
- 보이는 것처럼 최소 point(minX, minY)와  최대 point(maxX, maxY)를 통해 범위를 표시한다.

폴리곤에 포함된 좌표 구하기 
![image](https://github.com/2023vworks/heat-it-be/assets/57210007/96077f72-3ac0-426a-bb21-2f33ff109680)
- 이미지를 보면 폴리곤에 포함된 좌표들이 보인다 이것이 "폴리곤에 포함된 좌표 구하기"를 구하는 이다.

PosgGIS는 폴리곤 계산하여 포함여부 같은 연산을 함수로 지원한다.
```sql
SELECT *
FROM geo_data
WHERE ST_Contains(
    ST_MakeEnvelope(127.10646933077587, 37.51273616606448, 127.11595361763263, 37.516466400555935, 4326),
    coordinates
);
```
- ST_MakeEnvelope : 폴리곤 연산
- ST_Contains: 포함되는 좌표는 true 응답
- 조회 결과를 보면 13개가 나오는 것을 볼 수 있으며 이는 카카오지도에 표시된 데이터와 일치한다.

### 결론 좌표 데이터와 point 데이터를 둘다 DB에 저장하기로 하였다.
```typescript
export class GeoMark extends Timestamp {
  /**
   * 경도(x좌표)
   * - Double
   * - x = longtitue = 경도
   * - 대한민국 x축 범위: 33 ~ 43
   */
  @Column('decimal', { comment: '경도(x좌표)' })
  x: number;
  /**
   * 위도(y좌표)
   * - Double
   * - y = lattitue = 위도
   * - 대한민국 y축 범위: 124 ~ 132
   */
  @Column('decimal', { comment: '경위도(y좌표)' })
  y: number;

  /**
   * 좌표계 타입
   * - default 'WGS84'
   */
  @Column('enum', { enum: CoordType, comment: '좌표계 타입', default: 'WGS84' })
  type: CoordType;

  /**
   * Postgis의 geometry 타입
   * - point = POINT(x, y)
   * - POINT()는 postgresql의 내장함수이다.
   */
  @Column('geometry', { srid: 4326 })
  point: Point;
  
  // ...
}
```

## [TODO]
적은 데이터에서는 아래 두가지 방법에 큰 차이가 보이지 않는다.
  1. 소수점 비교를 통한 단순한 조회 
  2. PosgGIS에서 지원하는 폴리곤에 포함된 좌표를 조회
그렇기 때문에 몇 백개의 데이터를 넣고 테스트를 해봐야 한다.






