### PR TITLE
fix: 피드 리스트 조회 누락된 필드 추가

### DIFF
--- a/src/domain/feed/domain/feed.domain.ts
+++ b/src/domain/feed/domain/feed.domain.ts
@@ -15,7 +15,8 @@ export class FeedProps extends OmitType(FeedEntity, [
   'reportHistories',
   'geoMark',
 ]) {
-  comments: Comment[];
+  geoMarkId: number;
+  comments: Comment[] | [];
   user: FeedWriter;
   geoMark?: GeoMark | null;
 }
@@ -76,6 +77,10 @@ export class Feed extends BaseDomain<FeedProps> {
    */
   get activationAt(): Date {
     return this.props.activationAt;
+  }
+
+  get geoMarkId(): number {
+    return this.props.geoMarkId;
   }
 
   /**

--- a/src/domain/feed/domain/mapper/feed-entity-mapper.ts
+++ b/src/domain/feed/domain/mapper/feed-entity-mapper.ts
@@ -1,4 +1,4 @@
-import { FeedEntity } from '@app/entity';
+import { FeedEntity, GeoMarkEntity } from '@app/entity';
 import { GeoMarkEntityMapper } from 'src/domain/geo-mark/domain';
 import { Feed } from '../feed.domain';
 import { CommentEntityMapper } from './comment-entity-mapper';
@@ -11,15 +11,30 @@ export class FeedEntityMapper {
       ? entity.map((e) => this.toDomain(e))
       : new Feed({
           ...entity,
+          geoMarkId: entity.geoMark.id,
           comments: entity.comments
             ? CommentEntityMapper.toDomain(entity.comments)
             : [],
-          geoMark: entity.geoMark
+          geoMark: this.isExistGeoMark(entity.geoMark)
             ? GeoMarkEntityMapper.toDomain({
                 ...entity.geoMark,
                 activity: entity.activity,
               })
             : null,
         }).setBase(entity.id, entity.createdAt, entity.updatedAt);
+  }
+
+  private static isExistGeoMark(val: unknown): val is GeoMarkEntity {
+    return (
+      typeof val === 'object' &&
+      'id' in val &&
+      'x' in val &&
+      'y' in val &&
+      'type' in val &&
+      'point' in val &&
+      'srid' in val &&
+      'regionInfo' in val &&
+      'address' in val
+    );
   }
 }

--- a/src/domain/feed/dto/response/get-feed-response.dto.ts
+++ b/src/domain/feed/dto/response/get-feed-response.dto.ts
@@ -9,6 +9,7 @@ import {
 import {
   InstanceValidator,
   InstanceValidatorOptional,
+  IntValidator,
   defaultResponseProperties,
 } from '@app/common';
 import {
@@ -81,6 +82,16 @@ export class GetFeedResponseDTO extends PickType(FeedEntity, [
   @Expose()
   @InstanceValidator(GetFeedWithUserResponseDTO)
   user: GetFeedWithUserResponseDTO;
+
+  @ApiProperty({
+    description: '지도 마커 ID',
+    type: Number,
+    minimum: 1,
+    maximum: 2147483647,
+  })
+  @IntValidator()
+  @Expose()
+  geoMarkId: number;
 
   @ApiProperty({
     description: '지도 마커 정보',

--- a/src/domain/feed/dto/response/get-feeds-response.dto.ts
+++ b/src/domain/feed/dto/response/get-feeds-response.dto.ts
@@ -1,6 +1,10 @@
 import { ApiProperty, PickType } from '@nestjs/swagger';
 
-import { InstanceValidator, defaultResponseProperties } from '@app/common';
+import {
+  InstanceValidator,
+  IntValidator,
+  defaultResponseProperties,
+} from '@app/common';
 import { FeedEntity, UserEntity } from '@app/entity';
 import { Expose } from 'class-transformer';
 
@@ -14,6 +18,7 @@ export class GetFeedsResponseDTO extends PickType(FeedEntity, [
   'activity',
   'hashTags',
   'activationAt',
+  'content',
   'recommendCount',
   'unrecommendCount',
   'reportCount',
@@ -27,4 +32,14 @@ export class GetFeedsResponseDTO extends PickType(FeedEntity, [
   @Expose()
   @InstanceValidator(GetFeedsWithUserResponseDTO)
   user: GetFeedsWithUserResponseDTO;
+
+  @ApiProperty({
+    description: '지도 마커 ID',
+    type: Number,
+    minimum: 1,
+    maximum: 2147483647,
+  })
+  @IntValidator()
+  @Expose()
+  geoMarkId: number;
 }

--- a/src/domain/feed/feed.repository.ts
+++ b/src/domain/feed/feed.repository.ts
@@ -107,7 +107,8 @@ export class FeedRepositoryImpl
     qb.select();
     qb.innerJoin('feed.user', 'user') //
       .addSelect(['user.id', 'user.mbtiType', 'user.nickname']);
-    qb.innerJoin('feed.geoMark', 'mark');
+    qb.innerJoin('feed.geoMark', 'mark') //
+      .addSelect(['mark.id']);
 
     qb.where('feed."activationAt" >= now()');
     qb.andWhere('mark.x BETWEEN :minX AND :maxX', { minX, maxX });
@@ -133,7 +134,8 @@ export class FeedRepositoryImpl
     qb.select();
     qb.innerJoin('feed.user', 'user') //
       .addSelect(['user.id', 'user.mbtiType', 'user.nickname']);
-    qb.innerJoin('feed.geoMark', 'mark');
+    qb.innerJoin('feed.geoMark', 'mark') //
+      .addSelect(['mark.id']);
 
     qb.where('feed."activationAt" >= now()');
     qb.andWhere(
@@ -194,9 +196,10 @@ export class FeedRepositoryImpl
     const feed = await this.findOne({
       select: {
         user: { id: true, nickname: true, mbtiType: true },
+        geoMark: { id: true },
       },
       where: { id: feedId, activationAt: MoreThanOrEqual(new Date()) },
-      relations: { user: true },
+      relations: { user: true, geoMark: true },
     });
     return feed ? FeedEntityMapper.toDomain(feed) : null;
   }


### PR DESCRIPTION
## [FEATURE]

- [버그 리포트 - v0.0.1](https://www.notion.so/30e609e27b8548a1a65dc173a8f73ffe?p=acd6050eaf644a12a09ccd1166174895&pm=s)

## [HOW-TO] (optional)

    1. Feed 도메인 객체 수정
    - Feed#geoMarkId 추가
    
    2. 피드 리스트 조회 응답 DTO 추가된 필드
    - content
    - geoMarkId
    
    3. 피드 상세 조회 응답 DTO 추가된 필드
    - geoMarkId
