### PR TITLE
fix: WebP 이미지 제로데이 취약점으로 화이트리스트에서 제거

### DIFF
--- a/src/common/decorator/upload/upload-file.decorator.ts
+++ b/src/common/decorator/upload/upload-file.decorator.ts
@@ -12,10 +12,13 @@ type ValidationOptions = {
   isOption?: boolean;
 };
 
+const DEFAULT_PATTEN = process.env.UPLOAD_IMAGE_TYPE;
 const MB = 1 * 1024 * 1024;
 const defaultOptions = {
   maxSize: MB,
-  fileType: /^image\/(jpeg|jpg|png|gif|bmp|webp|svg\+xml)$/i,
+  fileType: DEFAULT_PATTEN
+    ? new RegExp(DEFAULT_PATTEN, 'i')
+    : /^image\/(jpeg|jpg|png|gif|bmp|svg\+xml)$/i,
   isOption: false,
 };
 


### PR DESCRIPTION
## [ISSUE] (optional)

    - WebP 이미지는 `CVE-2023-4863` 제로데이 취약점이 있기 때문에 화이트리스트에서 제거한다.
    - 크롬 취약점: https://blog.alyac.co.kr/5248
    - 애플 취약점: https://blog.alyac.co.kr/5244